### PR TITLE
core,server: refactor to load private key from different sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "toml",
+ "url",
  "uuid",
 ]
 

--- a/ostiarius-core/Cargo.toml
+++ b/ostiarius-core/Cargo.toml
@@ -12,4 +12,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.31"
 toml = "0.5"
+url = "2.2.2"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }

--- a/ostiarius-core/src/crypto/mod.rs
+++ b/ostiarius-core/src/crypto/mod.rs
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2022 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+mod openssl;
+
+use crate::{crypto::openssl::FileRsaPrivateKey, Error, Result};
+use url::Url;
+
+pub trait PrivateKey {
+    fn decrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize>;
+    fn size(&self) -> usize;
+}
+
+#[derive(Debug, Clone)]
+pub enum RsaPrivateKey {
+    File(FileRsaPrivateKey),
+}
+
+impl RsaPrivateKey {
+    pub fn from_uri(uri: &str) -> Result<RsaPrivateKey> {
+        let url = Url::parse(uri)?;
+        let key = match url.scheme() {
+            "file" => {
+                let key = FileRsaPrivateKey::from_pem_file(url.path())?;
+                RsaPrivateKey::File(key)
+            }
+            _ => return Err(Error::InvalidUri(uri.into())),
+        };
+        Ok(key)
+    }
+}
+
+impl PrivateKey for RsaPrivateKey {
+    fn decrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize> {
+        match self {
+            RsaPrivateKey::File(key) => key.decrypt(from, to),
+        }
+    }
+    fn size(&self) -> usize {
+        match self {
+            RsaPrivateKey::File(key) => key.size(),
+        }
+    }
+}

--- a/ostiarius-core/src/crypto/openssl.rs
+++ b/ostiarius-core/src/crypto/openssl.rs
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2022 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use crate::{crypto::PrivateKey, Result};
+use openssl::{
+    pkey::Private,
+    rsa::{Padding, Rsa},
+};
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct FileRsaPrivateKey {
+    inner: Rsa<Private>,
+}
+
+impl FileRsaPrivateKey {
+    pub fn from_pem_file<P: AsRef<Path>>(priv_key_path: P) -> Result<Self> {
+        let priv_key: Vec<u8> = std::fs::read(priv_key_path)?;
+        let inner = Rsa::private_key_from_pem(&priv_key)?;
+        Ok(FileRsaPrivateKey { inner })
+    }
+}
+
+impl PrivateKey for FileRsaPrivateKey {
+    fn decrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize> {
+        let size = self.inner.private_decrypt(from, to, Padding::PKCS1)?;
+        Ok(size)
+    }
+    fn size(&self) -> usize {
+        self.inner.size() as usize
+    }
+}

--- a/ostiarius-core/src/error.rs
+++ b/ostiarius-core/src/error.rs
@@ -7,6 +7,7 @@
 use openssl;
 use thiserror::Error;
 use toml;
+use url;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -16,10 +17,14 @@ pub enum Error {
     Crypto(#[from] openssl::error::ErrorStack),
     #[error("TOML deserialization error: {0}")]
     Toml(#[from] toml::de::Error),
+    #[error("URL parsing error: {0}")]
+    Url(#[from] url::ParseError),
     #[error("Unauthorized")]
     Unauthorized,
     #[error("Invalid path: {0:?}")]
     InvalidPath(std::ffi::OsString),
+    #[error("Invalid URI: {0}")]
+    InvalidUri(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/ostiarius-core/src/lib.rs
+++ b/ostiarius-core/src/lib.rs
@@ -5,7 +5,9 @@
 //
 
 pub mod authorization;
+pub mod crypto;
 pub mod error;
 
 pub use crate::authorization::*;
+pub use crate::crypto::{PrivateKey, RsaPrivateKey};
 pub use crate::error::*;


### PR DESCRIPTION
In order to prepare support for using an authorization checker private key from PKCS#11 token, refactor private key loading.

This PR introduces the `PrivateKey` trait, which is currently implemented by `RsaPrivateKey` and its lone variant `FileRsaPrivateKey`.

Note: an `enum` is used instead of a boxed trait object, which can not be `Clone` without too much complicating the code.