### PR TITLE
Add support for private key in PKCS11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cryptoki"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503aa2bd88796da9bc6baf2c47696da40f135721b3d6680c7c6cee0b7d1f7a59"
+dependencies = [
+ "cryptoki-sys",
+ "derivative",
+ "libloading",
+ "log",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec220169d3b1705b54bce57e459873828e5c3bf0e25b96e5f2142acbbb71dda"
+dependencies = [
+ "libloading",
+ "target-lexicon",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +502,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +696,7 @@ name = "ostiarius-core"
 version = "0.1.1"
 dependencies = [
  "chrono",
+ "cryptoki",
  "openssl",
  "rand",
  "serde",
@@ -670,6 +714,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "cryptoki",
  "gumdrop",
  "ostiarius-core",
  "serde",
@@ -993,6 +1038,12 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 
 [[package]]
 name = "tempfile"

--- a/ostiarius-core/Cargo.toml
+++ b/ostiarius-core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
+cryptoki = "0.3.0"
 openssl = {version = "0.10", features = ["vendored"] }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/ostiarius-core/src/crypto/pkcs11.rs
+++ b/ostiarius-core/src/crypto/pkcs11.rs
@@ -1,0 +1,204 @@
+//
+// Copyright (C) 2022 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use crate::{crypto::PrivateKey, Error, Result};
+use cryptoki::{
+    context::{CInitializeArgs, Pkcs11},
+    mechanism::Mechanism,
+    object::{Attribute, AttributeType, ObjectHandle},
+    session::{Session, SessionFlags, UserType},
+};
+use std::collections::HashMap;
+use std::str::FromStr;
+use url::Url;
+
+#[derive(Debug)]
+struct Pkcs11Params(HashMap<String, String>);
+
+impl FromStr for Pkcs11Params {
+    type Err = Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let items = s.split(";");
+        let result: std::result::Result<HashMap<String, String>, Self::Err> = items
+            .map(|kv| {
+                kv.find("=")
+                    .ok_or(Error::InvalidUri("malformed parameter".to_string()))
+                    .and_then(move |p| Ok((kv[0..p].to_string(), kv[p + 1..].replace("%20", " "))))
+            })
+            .collect();
+        Ok(Pkcs11Params(result?))
+    }
+}
+
+impl TryFrom<&Url> for Pkcs11Params {
+    type Error = Error;
+
+    fn try_from(url: &Url) -> std::result::Result<Self, Self::Error> {
+        let mut params = url.path().parse::<Pkcs11Params>()?;
+        let module_path = url
+            .query_pairs()
+            .filter_map(|(k, v)| {
+                if k == "module-path" {
+                    Some(v.to_string())
+                } else {
+                    None
+                }
+            })
+            .next()
+            .ok_or(Error::InvalidUri("missing module-path".to_string()))?;
+        params.0.insert("module-path".to_string(), module_path);
+        Ok(params)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Pkcs11Url {
+    module_path: String,
+    token: String,
+    pin: String,
+    object: String,
+}
+
+impl Pkcs11Url {
+    pub fn module_path(&self) -> &str {
+        &self.module_path
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    pub fn pin(&self) -> &str {
+        &self.pin
+    }
+
+    pub fn object(&self) -> &str {
+        &self.object
+    }
+}
+
+impl TryFrom<&Url> for Pkcs11Url {
+    type Error = Error;
+
+    fn try_from(url: &Url) -> std::result::Result<Self, Self::Error> {
+        let mut params = Pkcs11Params::try_from(url)?;
+        Ok(Pkcs11Url {
+            module_path: params
+                .0
+                .remove("module-path")
+                .ok_or(Error::InvalidUri("missing module-path".to_string()))?,
+            token: params
+                .0
+                .remove("token")
+                .ok_or(Error::InvalidUri("missing token".to_string()))?,
+            pin: params
+                .0
+                .remove("pin-value")
+                .ok_or(Error::InvalidUri("missing pin-value".to_string()))?,
+            object: params
+                .0
+                .remove("object")
+                .ok_or(Error::InvalidUri("missing object".to_string()))?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Pkcs11RsaPrivateKey {
+    url: Pkcs11Url,
+    pkcs11: Pkcs11,
+    size: usize,
+}
+
+impl Pkcs11RsaPrivateKey {
+    pub fn new(url: &Url) -> Result<Self> {
+        let url = Pkcs11Url::try_from(url)?;
+        let pkcs11 = Pkcs11::new(url.module_path())?;
+        pkcs11.initialize(CInitializeArgs::OsThreads)?;
+        let size = Self::get_size(&pkcs11, &url)?;
+        Ok(Pkcs11RsaPrivateKey { url, pkcs11, size })
+    }
+
+    fn open_session(pkcs11: &Pkcs11, url: &Pkcs11Url) -> Result<Session> {
+        let slots = pkcs11.get_slots_with_initialized_token()?;
+        if slots.len() == 0 {
+            return Err(Error::InvalidKey("No PKCS#11 token found".to_string()));
+        }
+
+        let mut flags = SessionFlags::new();
+        flags.set_rw_session(false);
+        flags.set_serial_session(true);
+        let session = pkcs11.open_session_no_callback(slots[0], flags)?;
+        session.login(UserType::User, Some(url.pin()))?;
+        Ok(session)
+    }
+
+    fn acquire(pkcs11: &Pkcs11, url: &Pkcs11Url) -> Result<(Session, ObjectHandle)> {
+        let session = Self::open_session(pkcs11, url)?;
+        let key_template = vec![
+            Attribute::Label(url.object().as_bytes().to_vec()),
+            Attribute::Private(true),
+            Attribute::Sign(true),
+        ];
+        let keys = session.find_objects(&key_template)?;
+        if keys.len() == 0 {
+            return Err(Error::InvalidKey("No such PKCS#11 key".to_string()));
+        }
+        Ok((session, keys[0]))
+    }
+
+    fn get_size(pkcs11: &Pkcs11, url: &Pkcs11Url) -> Result<usize> {
+        let (session, key) = Self::acquire(pkcs11, url)?;
+        let attr_types = vec![AttributeType::Modulus];
+        let attrs = session.get_attributes(key, &attr_types)?;
+        if attrs.len() == 0 {
+            return Err(Error::InvalidKey("No modulus".to_string()));
+        }
+        if let Attribute::Modulus(modulus) = &attrs[0] {
+            Ok(modulus.len())
+        } else {
+            Err(Error::InvalidKey("Unexpected key attribute".to_string()))
+        }
+    }
+}
+
+impl PrivateKey for Pkcs11RsaPrivateKey {
+    fn decrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize> {
+        let (session, key) = Self::acquire(&self.pkcs11, &self.url)?;
+        let data = session.decrypt(&Mechanism::RsaPkcs, key, from)?;
+        let limit = std::cmp::min(to.len(), data.len());
+        to[..limit].copy_from_slice(&data[..limit]);
+        Ok(limit)
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const INVALID_URL_NO_OBJECT: &'static str =
+        "pkcs11:token=Ostiarius%20Token%2001;pin-value=1234?module-path=/usr/lib64/libsofthsm2.so";
+    const INVALID_URL_NO_MODULE_PATH: &'static str =
+        "pkcs11:token=Ostiarius%20Token%2001;pin-value=1234;object=Ostiarius%20Server%20Key%2001";
+
+    #[test]
+    pub fn invalid_url_no_object() {
+        let url = url::Url::parse(INVALID_URL_NO_OBJECT).unwrap();
+        let result = Pkcs11RsaPrivateKey::new(&url);
+        assert!(matches!(result, Err(crate::error::Error::InvalidUri(_))));
+    }
+
+    #[test]
+    pub fn invalid_url_no_module_path() {
+        let url = url::Url::parse(INVALID_URL_NO_MODULE_PATH).unwrap();
+        let result = Pkcs11RsaPrivateKey::new(&url);
+        assert!(matches!(result, Err(crate::error::Error::InvalidUri(_))));
+    }
+}

--- a/ostiarius-core/src/error.rs
+++ b/ostiarius-core/src/error.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+use cryptoki;
 use openssl;
 use thiserror::Error;
 use toml;
@@ -13,8 +14,8 @@ use url;
 pub enum Error {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("Cryptographic error: {0}")]
-    Crypto(#[from] openssl::error::ErrorStack),
+    #[error("OpenSSL error: {0}")]
+    OpenSsl(#[from] openssl::error::ErrorStack),
     #[error("TOML deserialization error: {0}")]
     Toml(#[from] toml::de::Error),
     #[error("URL parsing error: {0}")]
@@ -25,6 +26,10 @@ pub enum Error {
     InvalidPath(std::ffi::OsString),
     #[error("Invalid URI: {0}")]
     InvalidUri(String),
+    #[error("PKCS#11 error: {0}")]
+    Pkcs11(#[from] cryptoki::error::Error),
+    #[error("Invalid key: {0}")]
+    InvalidKey(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/ostiarius-server/Cargo.toml
+++ b/ostiarius-server/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 anyhow = "1.0.59"
 axum = { version = "0.5.13", features = ["macros"] }
 chrono = { version = "0.4.19", features = ["serde"] }
+cryptoki = "0.3.0"
 gumdrop = "0.8.1"
 ostiarius-core = { path = "../ostiarius-core" }
 serde = { version = "1.0", features = ["derive"] }

--- a/ostiarius-server/README.md
+++ b/ostiarius-server/README.md
@@ -2,6 +2,13 @@
 
 ## Usage examples
 
+
+### Start server with private key in PKCS#11 token
+
+```sh
+ostiarius-server -P "pkcs11:token=Ostiarius%20Token%2001;pin-value=1234;object=Ostiarius%20Server%20Key%2001?module-path=/usr/lib64/libsofthsm2.so"
+```
+
 ### Get server info
 
 ```sh


### PR DESCRIPTION
This PR adds support for using server key stored in PKCS#11. It has been tested using softHSM2.

Documentation will be added in a later PR.