### PR TITLE
Add support for password protected private key file

### DIFF
--- a/ostiarius-core/src/crypto/mod.rs
+++ b/ostiarius-core/src/crypto/mod.rs
@@ -29,7 +29,7 @@ impl RsaPrivateKey {
         let url = Url::parse(uri)?;
         let key = match url.scheme() {
             "file" => {
-                let key = FileRsaPrivateKey::from_pem_file(url.path())?;
+                let key = FileRsaPrivateKey::new(&url)?;
                 RsaPrivateKey::File(key)
             }
             "pkcs11" => {


### PR DESCRIPTION
It is now possible to use a password-protected private key file by appending "?password=" and the value of the password to the private key URL.

Example, for a file protected by password "quux300":

  file:///path/to/server.privkey.pem?password=quux300

Fixes #7 