### PR TITLE
Add optional PKCS#11 support in client

### DIFF
--- a/ostiarius-client/Cargo.toml
+++ b/ostiarius-client/Cargo.toml
@@ -6,10 +6,14 @@ edition.workspace = true
 license.workspace = true
 description = "Ostiarius client program"
 
+[features]
+default = ["pkcs11"]
+pkcs11 = ["ostiarius-core/pkcs11"]
+
 [dependencies]
 anyhow = "1.0.59"
 gumdrop = "0.8.1"
 hostname = "0.3.1"
-ostiarius-core = { path = "../ostiarius-core" }
+ostiarius-core = { path = "../ostiarius-core", default-features = false }
 reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "json"] }
 uuid = "1.1.2"

--- a/ostiarius-core/Cargo.toml
+++ b/ostiarius-core/Cargo.toml
@@ -7,11 +7,13 @@ license.workspace = true
 description = "Ostiarius core functions"
 
 [features]
+default = ["pkcs11"]
 visible_password = []
+pkcs11 = ["dep:cryptoki"]
 
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
-cryptoki = "0.3.0"
+cryptoki = { version = "0.3.0", optional = true }
 openssl = {version = "0.10", features = ["vendored"] }
 percent-encoding = "2.2.0"
 rand = "0.8.5"

--- a/ostiarius-core/src/crypto/mod.rs
+++ b/ostiarius-core/src/crypto/mod.rs
@@ -6,12 +6,12 @@
 
 mod openssl;
 pub mod password;
+#[cfg(feature = "pkcs11")]
 mod pkcs11;
 
-use crate::{
-    crypto::{openssl::FileRsaPrivateKey, pkcs11::Pkcs11RsaPrivateKey},
-    Error, Result,
-};
+#[cfg(feature = "pkcs11")]
+use crate::crypto::pkcs11::Pkcs11RsaPrivateKey;
+use crate::{crypto::openssl::FileRsaPrivateKey, Error, Result};
 use url::Url;
 
 pub trait PrivateKey {
@@ -22,6 +22,7 @@ pub trait PrivateKey {
 #[derive(Debug, Clone)]
 pub enum RsaPrivateKey {
     File(FileRsaPrivateKey),
+    #[cfg(feature = "pkcs11")]
     Pkcs11(Pkcs11RsaPrivateKey),
 }
 
@@ -33,6 +34,7 @@ impl RsaPrivateKey {
                 let key = FileRsaPrivateKey::new(&url)?;
                 RsaPrivateKey::File(key)
             }
+            #[cfg(feature = "pkcs11")]
             "pkcs11" => {
                 let key = Pkcs11RsaPrivateKey::new(&url)?;
                 RsaPrivateKey::Pkcs11(key)
@@ -47,12 +49,14 @@ impl PrivateKey for RsaPrivateKey {
     fn decrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize> {
         match self {
             RsaPrivateKey::File(key) => key.decrypt(from, to),
+            #[cfg(feature = "pkcs11")]
             RsaPrivateKey::Pkcs11(key) => key.decrypt(from, to),
         }
     }
     fn size(&self) -> usize {
         match self {
             RsaPrivateKey::File(key) => key.size(),
+            #[cfg(feature = "pkcs11")]
             RsaPrivateKey::Pkcs11(key) => key.size(),
         }
     }

--- a/ostiarius-core/src/error.rs
+++ b/ostiarius-core/src/error.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-use cryptoki;
 use openssl;
 use thiserror::Error;
 use toml;
@@ -30,6 +29,7 @@ pub enum Error {
     InvalidPath(std::ffi::OsString),
     #[error("Invalid URI: {0}")]
     InvalidUri(String),
+    #[cfg(feature = "pkcs11")]
     #[error("PKCS#11 error: {0}")]
     Pkcs11(#[from] cryptoki::error::Error),
     #[error("Invalid key: {0}")]

--- a/ostiarius-core/src/utils.rs
+++ b/ostiarius-core/src/utils.rs
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn test_insert_password() {
-        let mut psswd = " <>#%+{}|\\^~[]`;/?:@=&$";
+        let psswd = " <>#%+{}|\\^~[]`;/?:@=&$";
         let url = "pkcs11:token=Ostiarius%20Token%2002?module-path=/usr/lib64/libsofthsm2.so";
         let test = insert_password(psswd, url).unwrap();
         assert_eq!(test, "pkcs11:token=Ostiarius%20Token%2002;pin-value=%20%3C%3E%23%25%2B%7B%7D%7C%5C%5E%7E%5B%5D%60%3B%2F%3F%3A%40%3D%26%24?module-path=/usr/lib64/libsofthsm2.so");


### PR DESCRIPTION
This pull request:

- reworks the `core` crate to have  `Requester` support private key in files or PKCS#11 tokens in the same way as `Checker`,  but making PKCS#11 optional.
- updates the `client` crate so that PKCS#11 support is optional (as it may be built for architectures where no PKCS#11 drivers are available).